### PR TITLE
Add Comment Version Control

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -315,6 +315,18 @@ plugins:
         url: 
         cover: 
 
+# ---------------------------------------------------------------------------------------
+# Comment Version Control
+# 以下是配置评论系统版本控制，可以自定义成 CDN 地址，
+# 如果需要修改，最好使用与默认配置相同的版本，以避免潜在的问题，
+# ** 如果你不知道如何设置，请不要做任何改动 **
+#
+# Here is the url prefix to configure the comment verion. Set CDN addresses you want to customize.
+# Be aware that you would better use the same version as default ones to avoid potential problems.
+# DO NOT EDIT THE FOLLOWING SETTINGS UNLESS YOU KNOW WHAT YOU ARE DOING
+# ---------------------------------------------------------------------------------------
+comment_version:
+  twikoo: https://cdn.staticfile.org/twikoo/1.6.8/twikoo.all.min.js
 
 # ---------------------------------------------------------------------------------------
 # Redefine Theme version (Please dont modify it)

--- a/_config.yml
+++ b/_config.yml
@@ -216,6 +216,7 @@ comment:
   # See: https://github.com/imaegoo/twikoo
   twikoo:
     visitor: true
+    version: 1.6.10 # Twikoo version, do not modify if you dont know what it is
     env_id: # Vercel or Tencent Cloud Function environment ID
     region: # environment region. If select Guangzhou, fill in "ap-guangzhou". (optional)
 
@@ -314,19 +315,6 @@ plugins:
         artist: 
         url: 
         cover: 
-
-# ---------------------------------------------------------------------------------------
-# Comment Version Control
-# 以下是配置评论系统版本控制，可以自定义成 CDN 地址，
-# 如果需要修改，最好使用与默认配置相同的版本，以避免潜在的问题，
-# ** 如果你不知道如何设置，请不要做任何改动 **
-#
-# Here is the url prefix to configure the comment verion. Set CDN addresses you want to customize.
-# Be aware that you would better use the same version as default ones to avoid potential problems.
-# DO NOT EDIT THE FOLLOWING SETTINGS UNLESS YOU KNOW WHAT YOU ARE DOING
-# ---------------------------------------------------------------------------------------
-comment_version:
-  twikoo: https://cdn.staticfile.org/twikoo/1.6.8/twikoo.all.min.js
 
 # ---------------------------------------------------------------------------------------
 # Redefine Theme version (Please dont modify it)

--- a/layout/_partials/comments/twikoo.ejs
+++ b/layout/_partials/comments/twikoo.ejs
@@ -1,7 +1,7 @@
 <% if(theme.comment.use === 'twikoo' && theme.comment.twikoo.env_id) { %>
     <div class="twikoo-container">
         <script <%= theme.pjax.enable === true ? 'data-pjax' : '' %>
-                src='<%- theme.comment_version.twikoo %>'
+                src='https://cdn.staticfile.org/twikoo/<%- theme.comment.twikoo.version %>/twikoo.all.min.js'
         ></script>
         <div id="twikoo-comment"></div>
         <script <%= theme.pjax.enable === true ? 'data-pjax' : '' %>>

--- a/layout/_partials/comments/twikoo.ejs
+++ b/layout/_partials/comments/twikoo.ejs
@@ -1,7 +1,7 @@
 <% if(theme.comment.use === 'twikoo' && theme.comment.twikoo.env_id) { %>
     <div class="twikoo-container">
         <script <%= theme.pjax.enable === true ? 'data-pjax' : '' %>
-                src="https://cdn.staticfile.org/twikoo/1.6.8/twikoo.all.min.js"
+                src='<%- theme.comment_version.twikoo %>'
         ></script>
         <div id="twikoo-comment"></div>
         <script <%= theme.pjax.enable === true ? 'data-pjax' : '' %>>
@@ -25,7 +25,7 @@
 <% } else if (theme.comment.use === 'twikoo' && theme.comment.twikoo.env_id && theme.comment.twikoo.region) { %>
     <div class="twikoo-container">
         <script <%= theme.pjax.enable === true ? 'data-pjax' : '' %>
-                src="https://cdn.staticfile.org/twikoo/1.6.8/twikoo.all.min.js"
+                src='<%- theme.comment_version.twikoo %>'
         ></script>
         <div id="twikoo-comment"></div>
         <script <%= theme.pjax.enable === true ? 'data-pjax' : '' %>>


### PR DESCRIPTION
Add Comment system version control, so user can change comment system version directly from _config.yml. As a test, it only add twikoo at this point.

This was inspired from hexo-theme-fluid

=========================
This may or may not be the best practices, but I do see some of the theme has similar function. 

Example: The _config.yml use twikoo 1.6.8 by default, I can change it to 1.6.9 directly without putting theme to theme/redefine/layout. And here are the test preview:
![comment_version_control](https://user-images.githubusercontent.com/5590839/223347815-8bfff539-b87a-4f9d-aacd-ac3a630ba8e6.png)
