### PR TITLE
head: fix `og:url`

### DIFF
--- a/layout/_partials/head.ejs
+++ b/layout/_partials/head.ejs
@@ -25,7 +25,7 @@
     <meta property="og:type" content="article">
     <meta property="og:title" content="<%= page.title || config.title || 'Redefine Theme' %>">
     <meta property="og:description" content="<%= page.description || config.description || 'Hexo Theme Redefine' %>">
-    <meta property="og:url" content="<%= config.url + page.path %>">
+    <meta property="og:url" content="<%= full_url_for(page.path) %>">
     <% if (theme.style.og_image.enable) { %>
         <meta property="og:image" content="<%= theme.style.og_image.image_url %>">
     <% }%>


### PR DESCRIPTION
head 裡面的 `og:url` 沒有正常的接合，少了一個 `/`，就像下面這樣
```html
<meta property="og:url" content="http://redefine.ohevan.comindex.html">
```

把原本的 `config.url + page.path` 換成 `full_url_for(page.path)` 就可以修好了
https://hexo.io/docs/helpers#full-url-for