### PR TITLE
navbar: fix navbar-drawer not open bug

### DIFF
--- a/source/js/layouts/navbarShrink.js
+++ b/source/js/layouts/navbarShrink.js
@@ -34,9 +34,13 @@ const navbarShrink = {
     }
 
     domList.forEach(v => {
-      v.addEventListener('click', () => {
-        document.body.classList.toggle('navbar-drawer-show');
-      });
+      if (!v.dataset.navbarInitialized)
+      {
+        v.dataset.navbarInitialized = 1;
+        v.addEventListener('click', () => {
+          document.body.classList.toggle('navbar-drawer-show');
+        });
+      }
     });
   }
 };


### PR DESCRIPTION
### 所解決的問題描述
手機版的 navbar 的選單開啟按鈕有的時候會無法運作

### 問題復現
前往 https://redefine.ohevan.com/ （需要是有選單展開按鈕的狹窄手機頁面）
不要進行任何的捲動，確保這是第一個到達的頁面，因為這會受到 `pjax` 的影響
此時會發現 navbar 的選單開啟按鈕 無法正常運作

### 問題根源
頁面剛載入完成時
下面的兩個地方都會執行 `navbarShrink.init()` 一次
https://github.com/EvanNotFound/hexo-theme-redefine/blob/main/source/js/layouts/navbarShrink.js#L44
https://github.com/EvanNotFound/hexo-theme-redefine/blob/main/source/js/main.js#L46

在執行了兩個 `navbarShrink.init()` 的狀態下 選單開啟按鈕會 無法正常運作
原因在於這個地方會被執行兩次
https://github.com/EvanNotFound/hexo-theme-redefine/blob/main/source/js/layouts/navbarShrink.js#L38
```javascript
      v.addEventListener('click', () => {
        document.body.classList.toggle('navbar-drawer-show');
      });
```

那個地方被執行兩次的意思就是 選單按鈕會有兩個相同的 `EventListener` 
做的事情是 `toggle('navbar-drawer-show')`
`toggle` 兩次的意思等於沒有 `toggle`
所以選單不會正常打開

然後如果這個時候進行了捲動的動作 下面的這個地方又會執行一次 `navbarShrink.init()`
https://github.com/EvanNotFound/hexo-theme-redefine/blob/main/source/js/utils.js#L70

所以這個時候按選單展開按鈕的話
會 `toggle('navbar-drawer-show')` 三次
做三次的時候選單展開就會正常運作了
因為 toggle 三次就等於 toggle 一次的效果


### 修補方式
新增 `EventListener` 前的檢查
讓那個 `EventListener` 只會註冊一次


### 修好後的樣子
https://ching367436.github.io/