### PR TITLE
navbar: fix auto_hide bug

### DIFF
--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -54,9 +54,7 @@ Global.initUtils = () => {
     registerWindowScroll() {
       window.addEventListener("scroll", () => {
         // style handle when scroll
-        if (this.isHasScrollPercent || this.isHasScrollProgressBar) {
-          this.updateScrollStyle();
-        }
+        this.updateScrollStyle();
 
         // TOC scroll handle
         if (


### PR DESCRIPTION
### 問題描述
當 `global.scroll_progress.bar` `global.scroll_progress.percentage` 的設定都是 `false` 時 
`navbar.auto_hide` 設定成 `true` 仍不會有 auto_hide 的效果

### 問題成因
auto_hide 的功能是由 `updateScrollStyle` 這個 function 來處理的
https://github.com/EvanNotFound/hexo-theme-redefine/blob/91fa018a194e69a198ef9861e8c811452708b560/source/js/utils.js#L45
https://github.com/EvanNotFound/hexo-theme-redefine/commit/afbb3e966f5d2b55dd16ee7797a4dab8ea532c2f

所以來看看 `updateScrollStyle` 什麼時候會被呼叫到
可以從下面這段 code 發現
`this.isHasScrollPercent || this.isHasScrollProgressBar` 成立的情況下才會執行到 `updateScrollStyle` 
然後才會執行到 auto_hide 的部分
所以 `this.isHasScrollPercent || this.isHasScrollProgressBar` 為 `false` 的時候 auto_hide 就不會正常運作

https://github.com/EvanNotFound/hexo-theme-redefine/blob/main/source/js/utils.js#L57-L59

```javascript
    registerWindowScroll() {
      window.addEventListener("scroll", () => {
        // style handle when scroll
        if (this.isHasScrollPercent || this.isHasScrollProgressBar) {
          this.updateScrollStyle();
        }
```

### 解決方法
把 `this.isHasScrollPercent || this.isHasScrollProgressBar` 的檢查處理掉