### PR TITLE
navbar: close drawer-navbar after click on submenu

### DIFF
--- a/layout/_partials/navbar.ejs
+++ b/layout/_partials/navbar.ejs
@@ -93,7 +93,7 @@
                     <% if (theme.navbar.links[i].submenus) { %>          
                         <% for (var submenu in theme.navbar.links[i].submenus){ %>
                             <li class="dropdown-item flex-center">
-                                <a class="dropdown-item" href="<%- url_for(theme.navbar.links[i].submenus[submenu]) %>"><%= __(submenu.toLowerCase()).toUpperCase() %></a>
+                                <a href="<%- url_for(theme.navbar.links[i].submenus[submenu]) %>"><%= __(submenu.toLowerCase()).toUpperCase() %></a>
                             </li>
                         <% } %>
                     <% } %>

--- a/source/js/layouts/navbarShrink.js
+++ b/source/js/layouts/navbarShrink.js
@@ -31,6 +31,7 @@ const navbarShrink = {
 
     if (document.querySelector('.navbar-drawer')) {
       domList.push(...document.querySelectorAll('.navbar-drawer .drawer-navbar-list .drawer-navbar-item'));
+      domList.push(...document.querySelectorAll('.navbar-drawer .drawer-navbar-list .dropdown-item'));
     }
 
     domList.forEach(v => {


### PR DESCRIPTION
### 問題復現
來到 https://redefine.ohevan.com/ 的手機版頁面
打開 navbar 選單
此時若點選在 `LINKS` 底下的 submenu 裡的 `SHOWCASE`
會正常跳轉到 https://redefine.ohevan.com/showcase
只不過跳轉過去的時候選單還是開著的

預期應該要和點選 navbar 裡的 `HOME` 時一樣關閉選單然後跳去 home 

### 修補方法
在 submenu 裡的東西被點的時候把選單關起來