### PR TITLE
head: remove repetitive apple-touch-icon tag

### DIFF
--- a/layout/_partials/head.ejs
+++ b/layout/_partials/head.ejs
@@ -4,7 +4,6 @@
     <meta name="keywords" content="<%= page.keywords || config.keywords || 'Hexo Theme Redefine' %>">
     <meta name="description" content="<%= page.description || config.description || 'Hexo Theme Redefine' %>">
     <meta name="author" content="<%= theme.info.author || config.author || 'Redefine Team' %>">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon-redefine.png">
     <!-- preconnect -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
`apple-touch-icon` 的 tag 重複出現
而第一次出現的 `apple-touch-icon` 的 `href` 會是 404 not found
所以把第一次出現的那個移除
https://github.com/EvanNotFound/hexo-theme-redefine/blob/main/layout/_partials/head.ejs#L7
https://github.com/EvanNotFound/hexo-theme-redefine/blob/main/layout/_partials/head.ejs#L30