### PR TITLE
head: remove repetitive description tag

### DIFF
--- a/layout/_partials/head.ejs
+++ b/layout/_partials/head.ejs
@@ -2,7 +2,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="keywords" content="<%= page.keywords || config.keywords || 'Hexo Theme Redefine' %>">
-    <meta name="description" content="<%= page.description || config.description || 'Hexo Theme Redefine' %>">
+    <% if (!theme.global.open_graph) { %>
+        <meta name="description" content="<%= page.description || config.description || 'Hexo Theme Redefine' %>">
+    <% }%>
     <meta name="author" content="<%= theme.info.author || config.author || 'Redefine Team' %>">
     <!-- preconnect -->
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
### 問題敘述
使用 Hexo 的 open-graph helper 的時候
他就會自動幫網站加上 `<meta name="description" >` 了
所以 `open_graph` 開著的時候會出現重複的 description tag

### 修補方法
判斷 `open_graph` 開著的時候就不要再額外放 description tag ，避免重複