### PR TITLE
navbar: close drawer after click on logo-title

### DIFF
--- a/source/js/layouts/navbarShrink.js
+++ b/source/js/layouts/navbarShrink.js
@@ -43,6 +43,14 @@ const navbarShrink = {
         });
       }
     });
+
+    const logoTitleDom = document.querySelector('.navbar-container .navbar-content .logo-title')
+    if (logoTitleDom && !logoTitleDom.dataset.navbarInitialized) {
+      logoTitleDom.dataset.navbarInitialized = 1;
+      logoTitleDom.addEventListener('click', () => {
+        document.body.classList.remove('navbar-drawer-show');
+      });
+    }
   }
 };
 


### PR DESCRIPTION
類似 #121
手機版頁面中打開 navbar 選單
點選 logo-title 時會回到首頁
但跳轉到首頁時選單還是開著的

預期應該要和點選 navbar 裡的 `HOME` 時一樣關閉選單然後跳去 home