### PR TITLE
giscus: add support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -289,7 +289,7 @@ comment:
   # Whether to enable comment
   enable: true
   # Comment system
-  system: waline # waline, gitalk, twikoo
+  system: waline # waline, gitalk, twikoo, giscus
   # System configuration
   config:
     # Waline comment system. See https://waline.js.org/
@@ -307,6 +307,21 @@ comment:
       version: 1.6.10 # Twikoo version, do not modify if you dont know what it is
       server_url: # Twikoo server URL. e.g. https://example.example.com
       region: # Twikoo region. can be empty
+    # Giscus comment system. See https://giscus.app/
+    giscus:
+      repo: # Github repository name
+      repo_id: # Github repository id
+      category: # Github discussion category
+      category_id: # Github discussion category id
+      mapping: pathname # Which value to use as the unique identifier for the page. e.g. pathname, url, title, og:title. DO NOT USE og:title WITH PJAX ENABLED since pjax will not update og:title when the page changes
+      strict: 0 # Whether to enable strict mode. e.g. 0, 1
+      reactions_enabled: 1 # Whether to enable reactions. e.g. 0, 1
+      emit_metadata: 0 # Whether to emit metadata. e.g. 0, 1
+      theme: preferred_color_scheme # Giscus theme. e.g. light, dark, dark_high_contrast, transparent_dark, preferred_color_scheme
+      lang: en # Giscus language. e.g. en, zh-CN, zh-TW
+      input_position: bottom # Place the comment box above/below the comments. e.g. top, bottom
+      loading: lazy # Load the comments lazily
+
 # COMMENT <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end
 
 

--- a/_config.yml
+++ b/_config.yml
@@ -317,7 +317,6 @@ comment:
       strict: 0 # Whether to enable strict mode. e.g. 0, 1
       reactions_enabled: 1 # Whether to enable reactions. e.g. 0, 1
       emit_metadata: 0 # Whether to emit metadata. e.g. 0, 1
-      theme: preferred_color_scheme # Giscus theme. e.g. light, dark, dark_high_contrast, transparent_dark, preferred_color_scheme
       lang: en # Giscus language. e.g. en, zh-CN, zh-TW
       input_position: bottom # Place the comment box above/below the comments. e.g. top, bottom
       loading: lazy # Load the comments lazily

--- a/layout/_partials/comments/comment.ejs
+++ b/layout/_partials/comments/comment.ejs
@@ -14,6 +14,9 @@
         <% } else if (theme.comment.system === 'twikoo') { %>
             <%- partial('twikoo') %>
         
+        <% } else if (theme.comment.system === 'giscus') { %>
+            <%- partial('giscus') %>
+        
         <% } %>
     <% } %>
 </div>

--- a/layout/_partials/comments/giscus.ejs
+++ b/layout/_partials/comments/giscus.ejs
@@ -8,7 +8,7 @@
     <script <%= theme.global.pjax === true ? 'data-pjax' : '' %> defer>
         async function loadGiscus() {
             // wait until styleStatus is available
-            while (!Global || !Global.styleStatus) await new Promise(r => setTimeout(r, 1000));
+            while (!Global || !Global.colorSchemeConfirmed) await new Promise(r => setTimeout(r, 1000));
             const giscusConfig = {
                 'src': 'https://giscus.app/client.js',
                 'data-repo': '<%= theme.comment.config.giscus.repo %>',
@@ -19,7 +19,7 @@
                 'data-strict': '<%= theme.comment.config.giscus.strict || '0' %>',
                 'data-reactions-enabled': '<%= theme.comment.config.giscus.reactions_enabled || '1' %>',
                 'data-emit-metadata': '<%= theme.comment.config.giscus.emit_metadata || '1' %>',
-                'data-theme': '<%= theme.comment.config.giscus.theme || 'preferred_color_scheme' %>',
+                'data-theme': Global.styleStatus.isDark ? 'dark' : 'light',
                 'data-lang': '<%= theme.comment.config.giscus.lang || 'en' %>',
                 'data-input-position': '<%= theme.comment.config.giscus.input_position || 'bottom' %>',
                 'data-loading': '<%= theme.comment.config.giscus.loading || 'lazy' %>',

--- a/layout/_partials/comments/giscus.ejs
+++ b/layout/_partials/comments/giscus.ejs
@@ -1,14 +1,12 @@
-<% if ( 
-        theme.comment.system==='giscus' && 
-        theme.comment.config.giscus.repo && 
+<% if (
+        theme.comment.system==='giscus' &&
+        theme.comment.config.giscus.repo &&
         theme.comment.config.giscus.repo_id &&
         theme.comment.config.giscus.category_id
     ) { %>
     <div id="giscus-container"></div>
     <script <%= theme.global.pjax === true ? 'data-pjax' : '' %> defer>
         async function loadGiscus() {
-            // wait until styleStatus is available
-            while (!Global || !Global.colorSchemeConfirmed) await new Promise(r => setTimeout(r, 1000));
             const giscusConfig = {
                 'src': 'https://giscus.app/client.js',
                 'data-repo': '<%= theme.comment.config.giscus.repo %>',
@@ -19,7 +17,7 @@
                 'data-strict': '<%= theme.comment.config.giscus.strict || '0' %>',
                 'data-reactions-enabled': '<%= theme.comment.config.giscus.reactions_enabled || '1' %>',
                 'data-emit-metadata': '<%= theme.comment.config.giscus.emit_metadata || '1' %>',
-                'data-theme': Global.styleStatus.isDark ? 'dark' : 'light',
+                'data-theme': 'preferred_color_scheme',
                 'data-lang': '<%= theme.comment.config.giscus.lang || 'en' %>',
                 'data-input-position': '<%= theme.comment.config.giscus.input_position || 'bottom' %>',
                 'data-loading': '<%= theme.comment.config.giscus.loading || 'lazy' %>',

--- a/layout/_partials/comments/giscus.ejs
+++ b/layout/_partials/comments/giscus.ejs
@@ -1,0 +1,44 @@
+<% if ( 
+        theme.comment.system==='giscus' && 
+        theme.comment.config.giscus.repo && 
+        theme.comment.config.giscus.repo_id &&
+        theme.comment.config.giscus.category_id
+    ) { %>
+    <div id="giscus-container"></div>
+    <script <%= theme.global.pjax === true ? 'data-pjax' : '' %> defer>
+        async function loadGiscus() {
+            // wait until styleStatus is available
+            while (!Global || !Global.styleStatus) await new Promise(r => setTimeout(r, 1000));
+            const giscusConfig = {
+                'src': 'https://giscus.app/client.js',
+                'data-repo': '<%= theme.comment.config.giscus.repo %>',
+                'data-repo-id': '<%= theme.comment.config.giscus.repo_id %>',
+                'data-category': '<%= theme.comment.config.giscus.category %>',
+                'data-category-id': '<%= theme.comment.config.giscus.category_id %>',
+                'data-mapping': '<%= theme.comment.config.giscus.mapping || 'pathname' %>',
+                'data-strict': '<%= theme.comment.config.giscus.strict || '0' %>',
+                'data-reactions-enabled': '<%= theme.comment.config.giscus.reactions_enabled || '1' %>',
+                'data-emit-metadata': '<%= theme.comment.config.giscus.emit_metadata || '1' %>',
+                'data-theme': '<%= theme.comment.config.giscus.theme || 'preferred_color_scheme' %>',
+                'data-lang': '<%= theme.comment.config.giscus.lang || 'en' %>',
+                'data-input-position': '<%= theme.comment.config.giscus.input_position || 'bottom' %>',
+                'data-loading': '<%= theme.comment.config.giscus.loading || 'lazy' %>',
+                'crossorigin': 'anonymous',
+                'async': true
+            }
+            const giscusScript = document.createElement('script');
+            for (const key in giscusConfig) {
+                giscusScript.setAttribute(key, giscusConfig[key]);
+            }
+            document.getElementById('giscus-container').appendChild(giscusScript);
+        }
+        if ('<%= theme.global.pjax %>') {
+            let loadGiscusTimeout = setTimeout(() => {
+                loadGiscus();
+                clearTimeout(loadGiscusTimeout);
+            }, 1000);
+        } else {
+            window.addEventListener('DOMContentLoaded', loadGiscus);
+        }
+    </script>
+<% } %>

--- a/source/js/tools/lightDarkSwitch.js
+++ b/source/js/tools/lightDarkSwitch.js
@@ -55,11 +55,7 @@ Global.initModeToggle = () => {
           await new Promise(r => setTimeout(r, 1000));
           giscusFrame = document.querySelector("iframe.giscus-frame");
         }
-        if (giscusFrame.classList.contains('giscus-frame--loading'))
-        {
-          while (giscusFrame.classList.contains('giscus-frame--loading')) await new Promise(r => setTimeout(r, 1000));
-          await new Promise(r => setTimeout(r, 730));
-        }
+        while (giscusFrame.classList.contains('giscus-frame--loading')) await new Promise(r => setTimeout(r, 1000));
         theme ??= Global.styleStatus.isDark ? 'dark' : 'light';
         giscusFrame.contentWindow.postMessage({
           giscus: {
@@ -83,7 +79,6 @@ Global.initModeToggle = () => {
       } else {
         this.isDarkPrefersColorScheme().matches ? this.enableDarkMode() : this.enableLightMode();
       }
-      Global.colorSchemeConfirmed = true;
     },
 
     initModeToggleButton() {

--- a/source/js/tools/lightDarkSwitch.js
+++ b/source/js/tools/lightDarkSwitch.js
@@ -9,7 +9,7 @@ Global.initModeToggle = () => {
     iconDom: document.querySelector('.tool-dark-light-toggle i'),
     mermaidLightTheme: typeof Global.theme_config.mermaid !== 'undefined' && typeof Global.theme_config.mermaid.style !== 'undefined' && typeof Global.theme_config.mermaid.style.light !== 'undefined' ? Global.theme_config.mermaid.style.light : 'default',
     mermaidDarkTheme: typeof Global.theme_config.mermaid !== 'undefined' && typeof Global.theme_config.mermaid.style !== 'undefined' && typeof Global.theme_config.mermaid.style.dark !== 'undefined' ? Global.theme_config.mermaid.style.dark : 'dark',
-    
+
 
     enableLightMode() {
       document.body.classList.remove('dark-mode');
@@ -18,6 +18,7 @@ Global.initModeToggle = () => {
       Global.styleStatus.isDark = false;
       Global.setStyleStatus();
       this.mermaidLightInit();
+      this.giscusLightInit();
     },
 
     enableDarkMode() {
@@ -27,6 +28,7 @@ Global.initModeToggle = () => {
       Global.styleStatus.isDark = true;
       Global.setStyleStatus();
       this.mermaidDarkInit();
+      this.giscusDarkInit();
     },
 
     mermaidLightInit() {
@@ -45,6 +47,34 @@ Global.initModeToggle = () => {
       }
     },
 
+    async setGiscusTheme(theme) {
+      if (document.querySelector('#giscus-container')) {
+        let giscusFrame = document.querySelector("iframe.giscus-frame");
+        while (!giscusFrame)
+        {
+          await new Promise(r => setTimeout(r, 1000));
+          giscusFrame = document.querySelector("iframe.giscus-frame");
+        }
+        while (giscusFrame.classList.contains('giscus-frame--loading')) await new Promise(r => setTimeout(r, 1000));
+        theme = theme ?? Global.styleStatus.isDark ? 'dark' : 'light';
+        giscusFrame.contentWindow.postMessage({
+          giscus: {
+            setConfig: {
+              theme: theme
+            }
+          }
+        }, "https://giscus.app");
+      }
+    },
+
+    giscusDarkInit() {
+      this.setGiscusTheme();
+    },
+
+    giscusLightInit() {
+      this.setGiscusTheme();
+    },
+
     isDarkPrefersColorScheme() {
       return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
     },
@@ -57,6 +87,7 @@ Global.initModeToggle = () => {
       } else {
         this.isDarkPrefersColorScheme().matches ? this.enableDarkMode() : this.enableLightMode();
       }
+      Global.colorSchemeConfirmed = true;
     },
 
     initModeToggleButton() {

--- a/source/js/tools/lightDarkSwitch.js
+++ b/source/js/tools/lightDarkSwitch.js
@@ -18,7 +18,7 @@ Global.initModeToggle = () => {
       Global.styleStatus.isDark = false;
       Global.setStyleStatus();
       this.mermaidLightInit();
-      this.giscusLightInit();
+      this.setGiscusTheme();
     },
 
     enableDarkMode() {
@@ -28,7 +28,7 @@ Global.initModeToggle = () => {
       Global.styleStatus.isDark = true;
       Global.setStyleStatus();
       this.mermaidDarkInit();
-      this.giscusDarkInit();
+      this.setGiscusTheme();
     },
 
     mermaidLightInit() {
@@ -55,8 +55,12 @@ Global.initModeToggle = () => {
           await new Promise(r => setTimeout(r, 1000));
           giscusFrame = document.querySelector("iframe.giscus-frame");
         }
-        while (giscusFrame.classList.contains('giscus-frame--loading')) await new Promise(r => setTimeout(r, 1000));
-        theme = theme ?? Global.styleStatus.isDark ? 'dark' : 'light';
+        if (giscusFrame.classList.contains('giscus-frame--loading'))
+        {
+          while (giscusFrame.classList.contains('giscus-frame--loading')) await new Promise(r => setTimeout(r, 1000));
+          await new Promise(r => setTimeout(r, 730));
+        }
+        theme ??= Global.styleStatus.isDark ? 'dark' : 'light';
         giscusFrame.contentWindow.postMessage({
           giscus: {
             setConfig: {
@@ -65,14 +69,6 @@ Global.initModeToggle = () => {
           }
         }, "https://giscus.app");
       }
-    },
-
-    giscusDarkInit() {
-      this.setGiscusTheme();
-    },
-
-    giscusLightInit() {
-      this.setGiscusTheme();
     },
 
     isDarkPrefersColorScheme() {


### PR DESCRIPTION
#163 

## 使用方式
到 https://giscus.app/ 頁面中的 Configuration 部分依照指示將資料填好。

填好之後下方的 Enable giscus 部分會出現類似以下的內容。

```html
<script src="https://giscus.app/client.js"
        data-repo="ching367436/ching367436.github.io"
        data-repo-id="R_kgDOJNMXOw"
        data-category="Announcements"
        data-category-id="DIC_kwDOJNMXO84CVdDe"
        data-mapping="title"
        data-strict="0"
        data-reactions-enabled="1"
        data-emit-metadata="0"
        data-input-position="bottom"
        data-theme="preferred_color_scheme"
        data-lang="en"
        crossorigin="anonymous"
        async>
</script>
```

將上面生成的各項對應資料填入 `_config.redefine.yml`，如下面這樣。
`data-theme`、`crossorigin` 不用填。
特別注意 `mapping` 的部分在 `pjax` 開啟的情況下不要選用 `og:title`，會出問題。

```yml
comment:
  system: giscus
  config:
    giscus:
      repo: Ching367436/ching367436.github.io # Github repository name
      repo_id: R_kgDOJNMXOw # Github repository id
      category: Announcements # Github discussion category
      category_id: DIC_kwDOJNMXO84CVdDe # Github discussion category id
      mapping: title
      strict: 0
      reactions_enabled: 1
      emit_metadata: 0
      lang: en
      input_position: bottom
      loading: not-lazy
```

在 #163 的所提及的 bug 已修補完成。