### PR TITLE
fix font path

### DIFF
--- a/source/fonts/fonts.css
+++ b/source/fonts/fonts.css
@@ -5,10 +5,10 @@
   font-weight: 400;
   font-display: swap;
   src: local("Noto Sans SC"),
-    url("/fonts/noto-sans-sc-v26-chinese-simplified-regular.woff2")
+    url("./fonts/noto-sans-sc-v26-chinese-simplified-regular.woff2")
       format("woff2"),
     /* Chrome 26+, Opera 23+, Firefox 39+ */
-      url("/fonts/noto-sans-sc-v26-chinese-simplified-regular.woff")
+      url("./fonts/noto-sans-sc-v26-chinese-simplified-regular.woff")
       format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* noto-sans-sc-700 - chinese-simplified */
@@ -18,16 +18,16 @@
   font-weight: 700;
   font-display: swap;
   src: local("Noto Sans SC"),
-    url("/fonts/noto-sans-sc-v26-chinese-simplified-700.woff2") format("woff2"),
+    url("./fonts/noto-sans-sc-v26-chinese-simplified-700.woff2") format("woff2"),
     /* Chrome 26+, Opera 23+, Firefox 39+ */
-      url("/fonts/noto-sans-sc-v26-chinese-simplified-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+      url("./fonts/noto-sans-sc-v26-chinese-simplified-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 /* noto-sans-cjk-variable - chinese-simplified */
 @font-face {
   font-family: "Noto Sans CJK";
   src: local("Noto Sans CJK"),
-    url("/fonts/NotoSansCJKsc-VF.ttf") format("truetype"); /* Chrome 26+, Opera 23+, Firefox 39+ */
+    url("./fonts/NotoSansCJKsc-VF.ttf") format("truetype"); /* Chrome 26+, Opera 23+, Firefox 39+ */
   font-weight: 300 900;
   font-style: normal;
   font-display: swap;
@@ -39,7 +39,7 @@
   font-family: "Ubuntu Mono";
   font-style: normal;
   font-weight: 400;
-  src: url("../fonts/ubuntu-mono-v15-latin-regular.woff2") format("woff2"),
+  src: url("./fonts/ubuntu-mono-v15-latin-regular.woff2") format("woff2"),
     /* Chrome 36+, Opera 23+, Firefox 39+ */
-      url("../fonts/ubuntu-mono-v15-latin-regular.woff") format("woff"); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+      url("./fonts/ubuntu-mono-v15-latin-regular.woff") format("woff"); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }


### PR DESCRIPTION
我是用Cloudflare Pages去构建和部署的，更新2.2.0之后，由于添加的NotoSansCJKsc-VF.ttf字体文件过大，超过了Pages 25M的限制导致hexo generate之后无法正确部署，由于构建是正常的，所以我调整了构建命令在hexo generate之后删除了public/fonts/NotoSansCJKsc-VF.ttf，之后就部署正常了，但是访问发现字体有问题，我在配置文件中使用了饿了吗的cdn，但是字体的路径都是错误的（见截图），看了下是fonts.css里字体文件的路径都变成了绝对路径。
<img width="566" alt="image" src="https://github.com/EvanNotFound/hexo-theme-redefine/assets/1726458/0e58d8cf-828b-4068-8cf5-66b2db28123b">
顺便NotoSansCJKsc-VF.ttf实在太大了😂