### PR TITLE
New social link supports QRcode drawer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -150,6 +150,9 @@ home_banner:
       twitter:  # your twitter URL
       email:  # your email
       # ...... # you can add more
+    # Social links with QRcode drawers
+    qrs:
+      weixin: # your Wechat QRcode image URL
 # HOME BANNER <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end
 
 

--- a/layout/_partials/home-banner.ejs
+++ b/layout/_partials/home-banner.ejs
@@ -66,6 +66,29 @@
                         <% } %>
                     <% } %>
                 <% } %>
+				<% for (const key in theme.home_banner.social_links.qrs) { %>
+                    <% if(theme.home_banner.social_links.qrs[key]) { %>
+                        <% if(key.includes("fa-")) { %>
+                            <span class="social-contact-item-qr">
+                                <a target="_blank">
+                                    <i class="<%= key %> fa-sm"></i>
+									<div class="social-qr-container fade-in-down-animation">
+										<img class="social-contacts-qr" src="<%- theme.home_banner.social_links.qrs[key] %>" />
+									</div>
+                                </a>
+                            </span>
+                        <% } else { %>
+                            <span class="social-contact-item-qr <%= key %>">
+                                <a target="_blank">
+                                    <i class="fa-brands fa-<%= key %>"></i>
+									<div class="social-qr-container fade-in-down-animation">
+										<img class="social-contacts-qr" src="<%- theme.home_banner.social_links.qrs[key] %>" />
+									</div>
+                                </a>
+                            </span>
+                        <% } %>
+                    <% } %>
+                <% } %>
             </div>
         <% } %>
     </div>

--- a/source/css/layout/_partials/home-banner.styl
+++ b/source/css/layout/_partials/home-banner.styl
@@ -84,3 +84,36 @@ $home-banner-icon-size = 1.6rem
 
         &:last-child
           margin-right 0
+
+      .social-contact-item-qr
+        margin-right 20px
+        cursor pointer
+        line-height 2
+        color #FFF
+
+        &:last-child
+          margin-right 0
+		  
+		    .social-qr-container
+          display none
+          position absolute
+          bottom 120%
+          left 50%
+          backdrop-filter blur(10px)
+          -webkit-backdrop-filter blur(10px)
+          box-shadow 0 0 10px 0 rgba(0, 0, 0, 0.5)
+          border-radius $redefine-border-radius-medium
+          box-shadow inset 0 0 2000px var(--home-banner-icons-container-background-color)
+          border 1.5px solid var(--home-banner-icons-container-border-color)
+          overflow hidden
+
+          .social-contacts-qr
+            display flex
+            width 150px
+            padding 15px
+
+      .social-contact-item-qr:hover .social-qr-container
+        display initial
+
+            
+      


### PR DESCRIPTION
Preview:

![Preview](https://github.com/EvanNotFound/hexo-theme-redefine/assets/32564494/583b154e-ff39-45f0-8063-4d7b1f319853)

You should edit your config to something like this:

```yml
  social_links:
    # Whether to enable
    enable: false
    # Social links
    links:
      github:  # your GitHub URL
      instagram: # your Instagram URL
      zhihu:  # your ZhiHu URL
      twitter:  # your twitter URL
      email:  # your email
      # ...... # you can add more
    # Social links with QRcode drawers
    qrs:
      weixin: # your Wechat QRcode image URL
```

You can paste any URL of images here, and if you don't want to use this feature you can just leave it blank.