### PR TITLE
fix issue #258

### DIFF
--- a/source/css/layout/article-content.styl
+++ b/source/css/layout/article-content.styl
@@ -180,6 +180,7 @@ $gap = 30px
       +redefine-mobile()
         margin-top 1.2rem
         font-size 1rem
+        flex-wrap wrap
 
       .tag-item
         margin 0 0.25rem


### PR DESCRIPTION
手机端tag显示超宽，所有tag都显示在一行，修正为自动换行，可以展示文章所有tag。