### PR TITLE
navbar: Fix menu overflow issue

### DIFF
--- a/source/css/layout/_partials/navbar.styl
+++ b/source/css/layout/_partials/navbar.styl
@@ -263,6 +263,8 @@ $logo-image-box-width = 46px
     transform-origin top
     z-index $z-index-2
     opacity 0
+    max-height 100vh  // 添加这行
+    overflow-y auto    // 添加这行
     transition-t('transform,opacity', '0,0.1', '0.38,0.38', 'ease,ease')
 
     .navbar-drawer-show &

--- a/source/css/layout/_partials/navbar.styl
+++ b/source/css/layout/_partials/navbar.styl
@@ -263,8 +263,8 @@ $logo-image-box-width = 46px
     transform-origin top
     z-index $z-index-2
     opacity 0
-    max-height 100vh  // 添加这行
-    overflow-y auto    // 添加这行
+    max-height 100vh
+    overflow-y auto
     transition-t('transform,opacity', '0,0.1', '0.38,0.38', 'ease,ease')
 
     .navbar-drawer-show &


### PR DESCRIPTION
- 修复了移动端菜单过长无法点击的问题
- Fixed the problem of the mobile menu being too long to click

**before**

https://github.com/EvanNotFound/hexo-theme-redefine/assets/59012240/4c255991-a4a7-41c9-a6ab-3ca079df6289

**after**


https://github.com/EvanNotFound/hexo-theme-redefine/assets/59012240/e91f4f2f-0202-498b-946b-dc88caf369f7


