### PR TITLE
home-banner: Adjust QR code image

### DIFF
--- a/source/css/layout/_partials/home-banner.styl
+++ b/source/css/layout/_partials/home-banner.styl
@@ -95,10 +95,11 @@ $home-banner-icon-size = 1.6rem
           margin-right 0
 		  
 		    .social-qr-container
+          width max-content
           display none
           position absolute
           bottom 120%
-          left 50%
+          right 0px
           backdrop-filter blur(10px)
           -webkit-backdrop-filter blur(10px)
           box-shadow 0 0 10px 0 rgba(0, 0, 0, 0.5)
@@ -114,6 +115,3 @@ $home-banner-icon-size = 1.6rem
 
       .social-contact-item-qr:hover .social-qr-container
         display initial
-
-            
-      


### PR DESCRIPTION
- Adjust the size of the QR code image
- Make `social-qr-container` and `social-contacts` right aligned.

before:
<img width="965" alt="Snipaste_2023-10-28_20-17-52" src="https://github.com/EvanNotFound/hexo-theme-redefine/assets/59012240/38487e18-1637-4395-b950-c808e87d7f54">
