### PR TITLE
hotfix: Update website counter API URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,7 +70,7 @@ global:
     percentage: true # percentage
   # Website counter
   website_counter:
-    url: https://busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js # counter API URL (no need to change)
+    url: https://vercount.one/js # counter API URL (no need to change)
     enable: true # enable website counter or not
     site_pv: true # site page view
     site_uv: true # site unique visitor

--- a/layout/_partials/footer.ejs
+++ b/layout/_partials/footer.ejs
@@ -12,7 +12,7 @@
             <%= date(new Date(), 'YYYY') %>&nbsp;&nbsp;<%- theme.footer.icon || '<i class="fa-regular fa-computer-classic"></i>' %>&nbsp;&nbsp;<a href="<%= config.root %>"><%= theme.info.author || config.author %></a>
         </div>
         <% if (theme.global.website_counter.enable === true) { %>
-            <script <%= theme.global.single_page === true ? 'data-swup-reload-script' : '' %> src="<%= theme.global.website_counter.url ? theme.global.website_counter.url : "//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js" %>"></script>
+            <script <%= theme.global.single_page === true ? 'data-swup-reload-script' : '' %> src="<%= theme.global.website_counter.url ? theme.global.website_counter.url : "//vercount.one/js" %>"></script>
             <div class="relative text-center lg:absolute lg:right-[20px] lg:top-1/2 lg:-translate-y-1/2 lg:text-right">
                 <% if (theme.global.website_counter.site_uv) { %>
                     <span id="busuanzi_container_site_uv" class="lg:!block">


### PR DESCRIPTION
Update the counter API URL in _config.yml and footer.ejs from 'https://busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js' to 'https://vercount.one/js'. This change enables accurate website visit count.