### PR TITLE
Fix aplayer bug

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -415,10 +415,12 @@ plugins:
         artist: # audio artist
         url: # audio url
         cover: # audio cover url
+        lrc: # audio cover lrc
 #      - name: # audio name
 #        artist: # audio artist
 #        url: # audio url
 #        cover: # audio cover url
+#        lrc: # audio cover lrc
       # .... you can add more audios here
   # Mermaid JS. Requires hexo-filter-mermaid-diagrams (npm i hexo-filter-mermaid-diagrams). See https://mermaid.js.org/
   mermaid:

--- a/source/css/layout/_modules/aplayer.styl
+++ b/source/css/layout/_modules/aplayer.styl
@@ -254,13 +254,6 @@ $aplayer-height-lrc= $aplayer-height + $lrc-height - 6
     display none
   }
 
-  .aplayer-icon-lrc {
-    pointer-events none
-    svg {
-      opacity 0.4
-    }
-  }
-
   .aplayer-icon-lrc-inactivity {
     svg {
       opacity 0.4

--- a/source/js/plugins/aplayer.js
+++ b/source/js/plugins/aplayer.js
@@ -24,6 +24,8 @@ if (isMini) {
   const ap = new APlayer({
     container: document.getElementById("aplayer"),
     fixed: true,
+    lrcType: 3,
     audio: audioList,
   });
+  document.querySelector(".aplayer-icon-lrc").click();
 }


### PR DESCRIPTION
### Bug

- The properties in the aplayer.styl file cause the lyrics button in Applayer to be invalid. (gray, unable to be triggered)
- The lyrics cannot be displayed after the lrc file is imported into the link.

### Complete

- Applayer lyrics button now triggers properly.
**Before:** The button was gray and could not be triggered. 
**Now:**

https://github.com/EvanNotFound/hexo-theme-redefine/assets/136422874/e023eee5-dbbc-4c53-afa5-3934b2c8bbdb

- The lrc file can be added correctly and the lyrics can be displayed, and the lyrics can be hidden by default when the page is loaded.