### PR TITLE
feat:sort archive-list by post's title when the date is same

### DIFF
--- a/layout/_widgets/archive-list.ejs
+++ b/layout/_widgets/archive-list.ejs
@@ -8,7 +8,7 @@
             </div>
             <% let previousDate = null; %>
             <ul class="article-list pl-0 md:pl-8 text-lg leading-[1.5]">
-                <% postYear.postList.sort((a,b) => a.title.localeCompare(b.title)).forEach(post => { %>
+                <% postYear.postList.sort((a,b) => (a.date > b.date ? -1 : (a.date < b.date ? 1 : a.title.localeCompare(b.title)))).forEach(post => { %>
                     <% const currentDate = date(post.date, 'MM-DD'); %>
                     <% if (previousDate !== currentDate) { %>
                         <% if (previousDate) { %>

--- a/layout/_widgets/archive-list.ejs
+++ b/layout/_widgets/archive-list.ejs
@@ -8,7 +8,7 @@
             </div>
             <% let previousDate = null; %>
             <ul class="article-list pl-0 md:pl-8 text-lg leading-[1.5]">
-                <% postYear.postList.forEach(post => { %>
+                <% postYear.postList.sort((a,b) => a.title.localeCompare(b.title)).forEach(post => { %>
                     <% const currentDate = date(post.date, 'MM-DD'); %>
                     <% if (previousDate !== currentDate) { %>
                         <% if (previousDate) { %>


### PR DESCRIPTION
the archive-list's order is totally random when element's date is same,like["1.abc","3.abc","2.abc"],I would like to sort them by their title when they have same date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Posts are now sorted alphabetically by title in the archive list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->