### PR TITLE
fix: correct time display of shuoshuo & Hitokoto author

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -122,6 +122,7 @@ home_banner:
     text: [] # subtitle text, array
     hitokoto:  # 一言配置
       enable: false # Whether to enable hitokoto
+      show_author: false # Whether to show author
       api: https://v1.hitokoto.cn # API URL, can add types, see https://developer.hitokoto.cn/sentence/#%E5%8F%A5%E5%AD%90%E7%B1%BB%E5%9E%8B-%E5%8F%82%E6%95%B0
     typing_speed: 100 # Typing speed (ms)
     backing_speed: 80 # Backing speed (ms)

--- a/layout/_widgets/essays.ejs
+++ b/layout/_widgets/essays.ejs
@@ -10,7 +10,7 @@
             <li class="w-full flex flex-row relative">
                 <div class="w-10 h-10 mr-4 rounded-lg overflow-hidden border border-border-color p-[1px] flex-shrink-0"><%- image_tag(theme.defaults.avatar, {class: "w-full h-full rounded-[6.2px]"}) %></div>
                 <div class="w-full border-border-color rounded-xl rounded-tl-none redefine-box-shadow-flat overflow-hidden">
-                    <div class="px-4 py-1.5 text-sm border-b border-border-color bg-zinc-50 dark:bg-zinc-800 text-third-text-color"><%- moment(e.date).locale(config.language).calendar() %></div>
+                    <div class="px-4 py-1.5 text-sm border-b border-border-color bg-zinc-50 dark:bg-zinc-800 text-third-text-color"><%- moment(e.date).utc().locale(config.language).calendar() %></div>
                     <div id="shuoshuo-content" class="px-4 py-2"><%- markdown(e.content) %></div>
                 </div>
                 <div class=" absolute left-[50.5px] top-3 transform w-2 h-2 border-solid border-t border-l bg-zinc-50 -rotate-45 border-border-color dark:bg-zinc-800"></div>

--- a/source/js/plugins/typed.js
+++ b/source/js/plugins/typed.js
@@ -38,7 +38,11 @@ export default function initTyped(id) {
     fetch(usrHitokotoAPI)
       .then((response) => response.json())
       .then((data) => {
-        typing(data.hitokoto);
+        if (data.from_who && theme.home_banner.subtitle.hitokoto.show_author) {
+          typing(data.hitokoto + "——" + data.from_who);
+        } else {
+          typing(data.hitokoto);
+        }
       })
       .catch(console.error);
   } else {


### PR DESCRIPTION
Change the time zone of the shuoshuo to UTC to avoid time errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced date handling by displaying dates in Coordinated Universal Time (UTC), ensuring consistency across different time zones for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->