### PR TITLE
Fix unreadable code block color for diff

### DIFF
--- a/source/css/common/codeblock/highlight.styl
+++ b/source/css/common/codeblock/highlight.styl
@@ -179,11 +179,11 @@ pre
     color var(--highlight-bullet)
 
   .addition
-    background-color var(--highlight-addition)
+    color var(--highlight-addition)
     display inline-block
     width 100%
 
   .deletion
-    background-color var(--highlight-deletion)
+    color var(--highlight-deletion)
     display inline-block
     width 100%


### PR DESCRIPTION
此前的版本中，`addition`和`deletion`应用颜色到背景，导致出现了 #437 的问题，diff块代码可读性很差。通过将颜色应用到前景提高对比度，使颜色高亮与官方一致。

![屏幕截图_20241112_011531](https://github.com/user-attachments/assets/86145df7-b530-4635-8fbe-777baed3517c)

另：图中的``@@ ... @@``在hljs中被识别为`meta`，应当标记为蓝色，但是在这里被识别为`line`，仍然是白色，由于不知道主题中hljs具体的实现方式，没有修

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual representation for code changes by modifying the display of additions and deletions.
- **Bug Fixes**
	- Improved clarity in code block styles by simplifying the color representation for additions and deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->