### PR TITLE
ci: upgrade Vercel deployment GitHub Action to v1.2.0

### DIFF
--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Deploy to Vercel Action
         id: deploy-to-vercel
-        uses: EvanNotFound/vercel-deployment-for-github-actions@v1.1.0
+        uses: EvanNotFound/vercel-deployment-for-github-actions@v1.2.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Change directory to hexo-site
         run: echo "HEXO_SITE_DIR=${{ github.workspace }}/hexo-site" >> $GITHUB_ENV
 
+      - name: Install Vercel CLI
+        run: npm install -g vercel@22.0.1
+
       - name: Deploy to Vercel Action
         id: deploy-to-vercel
         uses: EvanNotFound/vercel-deployment-for-github-actions@v1.2.0

--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Change directory to hexo-site
         run: echo "HEXO_SITE_DIR=${{ github.workspace }}/hexo-site" >> $GITHUB_ENV
 
+      - name: Install Vercel CLI
+        run: npm install -g vercel@22.0.1
+
       - name: Deploy to Vercel Action
         uses: EvanNotFound/vercel-deployment-for-github-actions@v1.1.0
         with:


### PR DESCRIPTION
- Update Vercel deployment action from v1.1.0 to v1.2.0
- Ensure latest version of GitHub Action is used for deployment