### PR TITLE
修复 404  页面无法被正确显示的问题

### DIFF
--- a/scripts/events/404.js
+++ b/scripts/events/404.js
@@ -3,13 +3,14 @@
  * 404 error page
 */
 
-hexo.extend.generator.register('404', function(locals){
+hexo.extend.generator.register('404', function (locals) {
   return {
     path: '404.html',
     layout: '404',
     data: {
       title: 'Page Not Found',
-      page: locals.pages.findOne({path: '404.html'})
+      type: 'notfound',
+      page: locals.pages.findOne({ path: '404.html' })
     }
   }
 });


### PR DESCRIPTION
之前想自定义 404 页面发现怎么没反应，检查了半天发现 `page-helpers.js` 文件中 `notFound` pageData 下配置 `titles` 是 `["404", "notfound"]`，`types` 是 `["404", "notfound"]`，而在 `404.js` 文件中注册的 404 页面 data 为
``` JavaScript
{
      title: 'Page Not Found',
      page: locals.pages.findOne({ path: '404.html' })
}
```
这里 `title` 不符合 `page-helpers.js` 中 `notFound` 页面模板的规则，就加了一行 `type: 'notfound',`，之后就可以正确显示模板内容了

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the error handling for pages that aren’t found. The update refines the underlying structure for processing 404 errors, ensuring more consistent categorization and clarity. While the core behavior remains unchanged for users, these improvements fortify our error page delivery, set the stage for future optimizations, and provide additional benefits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->