### PR TITLE
fix: correct date formatting in essays.ejs to ensure proper timezone handling #515 #465

### DIFF
--- a/layout/pages/shuoshuo/essays.ejs
+++ b/layout/pages/shuoshuo/essays.ejs
@@ -12,7 +12,8 @@
 			</div>
 			<div class="w-full border-border-color rounded-xl rounded-tl-none shadow-redefine-flat overflow-hidden">
 				<!-- Pass the raw date here in a data attribute -->
-				<div class="essay-date px-4 py-1.5 text-sm border-b border-border-color bg-zinc-50 dark:bg-zinc-800 text-third-text-color" data-date="<%= moment(e.date).tz(timezone).format() %>">Loading Date...</div>
+				<% rawDate = moment(e.date).utc().format('YYYY-MM-DD HH:mm:ss') %>
+				<div class="essay-date px-4 py-1.5 text-sm border-b border-border-color bg-zinc-50 dark:bg-zinc-800 text-third-text-color" data-date="<%= moment(rawDate).tz(timezone).format() %>">Loading Date...</div>
 				<div id="shuoshuo-content" class="px-4 py-2"><%- markdown(e.content) %></div>
 			</div>
 			<div class="absolute left-[50.5px] top-3 transform w-2 h-2 border-solid border-t border-l bg-zinc-50 -rotate-45 border-border-color dark:bg-zinc-800"></div>


### PR DESCRIPTION
I fixed the timezone problem. The issue address is [#515](https://github.com/EvanNotFound/hexo-theme-redefine/issues/515).