### PR TITLE
fix(theme): fix theme flash and optimize dark/light toggle logic

### DIFF
--- a/layout/components/header/head.ejs
+++ b/layout/components/header/head.ejs
@@ -31,9 +31,6 @@
                 const isDark = theme === DARK;
                 const root = document.documentElement;
                 
-                // Set data attribute for CSS variables
-                root.setAttribute("data-theme", theme);
-                
                 // Set classes for compatibility
                 root.classList.add(theme);
                 root.classList.remove(isDark ? LIGHT : DARK);
@@ -52,69 +49,26 @@
                 }
             });
             
-            // Set body classes once DOM is ready
-            if (document.readyState !== "loading") {
-                document.body.classList.add(theme + "-mode");
-            } else {
-                document.addEventListener("DOMContentLoaded", () => {
-                    document.body.classList.add(theme + "-mode");
-                    document.body.classList.remove((theme === DARK ? LIGHT : DARK) + "-mode");
+            // Set body classes ASAP (before DOMContentLoaded)
+            (function() {
+                const addBodyClass = () => {
+                    const b = document.body;
+                    if (!b) return false;
+                    b.classList.add(theme + "-mode");
+                    return true;
+                };
+
+                // Try immediately
+                if (addBodyClass()) return;
+
+                // Observe until body exists
+                const mo = new MutationObserver(() => {
+                    if (addBodyClass()) mo.disconnect();
                 });
-            }
+                mo.observe(document.documentElement, { childList: true, subtree: true });
+            })();
         })();
     </script>
-    
-    <!-- Critical CSS to prevent flash -->
-    <style>
-        :root[data-theme="dark"] {
-            --background-color: #202124;
-            --background-color-transparent: rgba(32, 33, 36, 0.6);
-            --second-background-color: #2d2e32;
-            --third-background-color: #34353a;
-            --third-background-color-transparent: rgba(32, 33, 36, 0.6);
-            --primary-color: #0066CC;
-            --first-text-color: #ffffff;
-            --second-text-color: #eeeeee;
-            --third-text-color: #bebec6;
-            --fourth-text-color: #999999;
-            --default-text-color: #bebec6;
-            --invert-text-color: #373D3F;
-            --border-color: rgba(255, 255, 255, 0.08);
-            --selection-color: #0066CC;
-            --shadow-color-1: rgba(255, 255, 255, 0.08);
-            --shadow-color-2: rgba(255, 255, 255, 0.05);
-        }
-        
-        :root[data-theme="light"] {
-            --background-color: #fff;
-            --background-color-transparent: rgba(255, 255, 255, 0.6);
-            --second-background-color: #f8f8f8;
-            --third-background-color: #f2f2f2;
-            --third-background-color-transparent: rgba(241, 241, 241, 0.6);
-            --primary-color: #0066CC;
-            --first-text-color: #16171a;
-            --second-text-color: #2f3037;
-            --third-text-color: #5e5e5e;
-            --fourth-text-color: #eeeeee;
-            --default-text-color: #373D3F;
-            --invert-text-color: #bebec6;
-            --border-color: rgba(0, 0, 0, 0.08);
-            --selection-color: #0066CC;
-            --shadow-color-1: rgba(0, 0, 0, 0.08);
-            --shadow-color-2: rgba(0, 0, 0, 0.05);
-        }
-        
-        body {
-            background-color: var(--background-color);
-            color: var(--default-text-color);
-        }
-        
-        /* Apply body classes as soon as DOM is ready */
-        :root[data-theme="dark"] body {
-            background-color: var(--background-color);
-            color: var(--default-text-color);
-        }
-    </style>
     
     <!-- preconnect -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/source/css/common/theme.styl
+++ b/source/css/common/theme.styl
@@ -63,10 +63,10 @@ $default-mode = $temp-mode == 'dark' ? 'dark' : 'light'
   root-color($default-mode)
 }
 
-.light-mode {
+.light {
   root-color('light')
 }
 
-.dark-mode {
+.dark {
   root-color('dark')
 }


### PR DESCRIPTION
### 背景说明
针对 #558 进行的修复，原有 `head.ejs` 中的处理方式虽然能修复闪屏，但在刷新时还是会有部分元素的样式会闪烁（例如首页文章、footer），并且手动切换亮/暗模式会有部分样式无法正确加载（例如 `statistics.ejs` 的文字颜色），此次改动对原有方法和逻辑进行了调整，解决了上述问题。 
<img width="1904" height="923" alt="Flash" src="https://github.com/user-attachments/assets/336f1199-f2b5-48bd-b219-7bbc505cc668" />
<img width="1904" height="923" alt="LoadingFailed" src="https://github.com/user-attachments/assets/ea5bb4f1-0893-44a5-87a3-13a3ec7537eb" />

### 问题修复
- 修复了刷新页面时部分元素样式闪烁问题，使用立即执行函数 + MutationObserver 提前在 body 出现时就添加类，优化了 body class 注入逻辑，确保在 DOM 加载前正确应用主题，并移除原有的冗余代码
- 修复了手动切换亮/暗模式会有部分样式无法正确加载的问题，在 `theme.styl` 中取消根据在 `<body>` 上设置的 `.light-mode` / `.dark-mode` 切换亮暗模式，改为在 `<html>` 上使用 `.light` / `.dark`，与 TailwindCSS 的 dark variant 保持一致，这样可以确保所有依赖 `html.dark` / `html.light` 的样式正确切换，解决了部分元素样式无法更新的问题