### PR TITLE
fix: qr animation transition

### DIFF
--- a/source/css/common/animated.styl
+++ b/source/css/common/animated.styl
@@ -1,8 +1,8 @@
 transition-g()
-  transition-property color, background, box-shadow, border-color
-  transition-delay 0s, 0s, 0s, 0s
-  transition-duration 0.2s, 0.2s, 0.2s, 0.2s
-  transition-timing-function ease, ease, ease, ease
+  transition-property color, background, box-shadow, border-color, opacity, translate, visibility
+  transition-delay 0s, 0s, 0s, 0s, 0s, 0s, 0s
+  transition-duration 0.2s, 0.2s, 0.2s, 0.2s, 0.2s, 0.2s, 0.2s
+  transition-timing-function ease, ease, ease, ease, ease, ease, ease
 
 transition-t(property, delay, duration, function)
   $temp-property = 'color, background, box-shadow, border-color'


### PR DESCRIPTION
## Description
After upgrading to Tailwind CSS v4 in v2.8.4, the QR code show/hide animation in the home banner is missing.

## Related Issues
- #553 

## Analysis
1. QR code container in `home-banner.ejs` uses the `transition-all` class
2. This animation involves: `opacity`, `translate`, and `visibility`
3. The `transition-g()` function's `transition-property` is missing above 3 properties
4. This causes animations to become abrupt instead of smooth transitions

## Solution
Add the missing transition properties to the `transition-g()` function in `animated.styl`:
- `opacity`
- `translate` 
- `visibility`

