### PR TITLE
feat: 添加了个人/单篇Blog文章的Schema Org

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,11 @@ info:
   author: The Redefine Team
   # Site URL
   url: https://redefine.ohevan.com
+  person_schema:
+    personal_url: https://your-personal-url.com # 个人主页 URL，用于 Person Schema 的 url 和 sameAs 属性
+    social_links: # 社交媒体链接，用于 Person 和 Organization Schema 的 sameAs 属性
+      github: https://github.com/your-github
+      email: mailto:your-email@example.com
 # BASIC INFORMATION <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end
 
 

--- a/layout/components/header/head.ejs
+++ b/layout/components/header/head.ejs
@@ -90,7 +90,7 @@
     <% } %>
     <!--- Seo Part-->
     <%- generateMeta(theme, page) %>
-    <%- autoCanonical(config, page) %>
+    <%# autoCanonical(config, page) %>
     <meta name="robots" content="index,follow">
     <meta name="googlebot" content="index,follow">
     <meta name="revisit-after" content="1 days">
@@ -218,5 +218,35 @@
     <% if (theme.fontawesome.sharp_solid == true) { %>
         <%- renderCSS('fontawesome/sharp-solid.min.css') %>
     <% } %>
-</head>
 
+    <% if (is_post()) { %>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "<%- url_for(page.path) %>"
+      },
+      "headline": "<%- page.title %>",
+      "image": [
+        "<%- url_for(page.og_image || theme.global.open_graph?.image || theme.defaults.logo) %>"
+      ],
+      "datePublished": "<%- date_xml(page.date) %>",
+      "dateModified": "<%- date_xml(page.updated || page.date) %>",
+      "author": {
+        "@type": "Person",
+        "name": "<%- theme.info.author || config.author %>"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "<%- theme.info.title || config.title %>",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "<%- url_for(theme.defaults.logo) %>"
+        }
+      },
+      "description": "<%- page.description || page.excerpt || strip_html(page.content).substring(0, 150) %>"
+    }
+    </script>
+    <% } %>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -2,6 +2,69 @@
 <html lang="<%= config.language %>">
 <%- partial('components/header/head') %>
 
+    <% if (is_home()) { %>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "<%- config.url %>/#website",
+          "url": "<%- config.url %>/",
+          "name": "<%- theme.info.title || config.title %>",
+          "description": "<%- theme.info.subtitle || config.subtitle %>",
+          "publisher": {
+            "@id": "<%- config.url %>/#organization"
+          },
+          "inLanguage": "<%- config.language %>"
+        },
+        {
+          "@type": "Organization",
+          "@id": "<%- config.url %>/#organization",
+          "name": "<%- theme.info.title || config.title %>",
+          "url": "<%- config.url %>/",
+          "logo": {
+            "@type": "ImageObject",
+            "@id": "<%- config.url %>/#logo",
+            "url": "<%- url_for(theme.defaults.logo) %>",
+            "contentUrl": "<%- url_for(theme.defaults.logo) %>",
+            "width": "120",
+            "height": "120"
+          },
+          "sameAs": [
+            <% if (theme.info.person_schema && theme.info.person_schema.social_links) { %>
+              <% for (let key in theme.info.person_schema.social_links) { %>
+                "<%- theme.info.person_schema.social_links[key] %>"<%= (Object.keys(theme.info.person_schema.social_links).indexOf(key) === Object.keys(theme.info.person_schema.social_links).length - 1) ? '' : ',' %>
+              <% } %>
+            <% } %>
+          ]
+        },
+        {
+          "@type": "Person",
+          "@id": "<%- config.url %>/#person",
+          "name": "<%- theme.info.author || config.author %>",
+          "url": "<%- theme.info.person_schema.personal_url || config.url %>",
+          "image": {
+            "@type": "ImageObject",
+            "@id": "<%- config.url %>/#personlogo",
+            "url": "<%- url_for(theme.defaults.avatar) %>",
+            "contentUrl": "<%- url_for(theme.defaults.avatar) %>",
+            "width": "250",
+            "height": "250"
+          },
+          "sameAs": [
+            <% if (theme.info.person_schema && theme.info.person_schema.social_links) { %>
+              <% for (let key in theme.info.person_schema.social_links) { %>
+                "<%- theme.info.person_schema.social_links[key] %>"<%= (Object.keys(theme.info.person_schema.social_links).indexOf(key) === Object.keys(theme.info.person_schema.social_links).length - 1) ? '' : ',' %>
+              <% } %>
+            <% } %>
+          ]
+        }
+      ]
+    }
+    </script>
+    <% } %>
+
 <body>
 	<%- body %>
 	<%- partial('components/scripts') %>


### PR DESCRIPTION
在 _config.yml 的 info 部分新增 person_schema 配置块，用于定义个人主页 URL 和社交媒体链接。个人和组织相关的 Schema 信息可以方便地通过主题配置文件进行管理

```
# ... 其他现有配置 ...
person_schema:
   personal_url: https://your-personal-url.com # 个人主页
     URL，用于 Person Schema 的 url 和 sameAs 属性
   social_links: # 社交媒体链接，用于 Person 和
     Organization Schema 的 sameAs 属性
   github: https://github.com/your-github
   email:
     mailto:your-email@example.com
```
   - 注入 `WebSite`, `Organization`, `Person` 结构化数据：修改 layout/layout.ejs 文件，在 <body> 标签之前注入 JSON-LD 格式的 WebSite, Organization, Person 等结构化数据脚本块。该结构化数据通过 is_home() 条件判断，确保仅在网站首页生成，避免在其他页面重复或不必要的 Schema 输出 `BlogPosting` Schema同样有 (is_post()) 判断，为单篇blog内容生成单独的schema

  这样做的目的
   - 搜索引擎能更准确地理解网站的结构、内容主题、作者身份和品牌信息
   - 提高在 Google 搜索结果中显示富媒体的机会

