### PR TITLE
ci: split preview environments and widen PR preview trigger

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -14,7 +14,7 @@ jobs:
   preview-deployment:
     runs-on: ubuntu-latest
     environment:
-      name: Preview
+      name: Dev Preview
       url: ${{ steps.deploy-to-vercel.outputs.PREVIEW_URL }}
     steps:
       - name: Checkout theme repository
@@ -109,6 +109,7 @@ jobs:
           WORKING_DIRECTORY: ${{ env.HEXO_SITE_DIR }}
           VERCEL_SCOPE: ${{ secrets.VERCEL_SCOPE }}
           PRODUCTION: false
+          GITHUB_DEPLOYMENT: false
           DEPLOY_PR_FROM_FORK: true
           ALIAS_DOMAINS: |
             redefine-preview.vercel.app

--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -3,16 +3,7 @@ name: PR Preview Build
 on:
   pull_request:
     branches:
-      - main
       - dev
-    paths:
-      - "source/js/**"
-      - "source/css/**"
-      - "scripts/**"
-      - "languages/**"
-      - "package.json"
-      - "package-lock.json"
-      - "_config.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -19,6 +19,9 @@ jobs:
   deploy:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
+    environment:
+      name: PR Preview
+      url: ${{ steps.deploy-to-vercel.outputs.PREVIEW_URL }}
 
     steps:
       - name: Resolve PR Info
@@ -65,6 +68,7 @@ jobs:
           WORKING_DIRECTORY: deploy
           VERCEL_SCOPE: ${{ secrets.VERCEL_SCOPE }}
           PRODUCTION: false
+          GITHUB_DEPLOYMENT: false
           PREBUILT: true
           DEPLOY_PR_FROM_FORK: true
           ALIAS_DOMAINS: |

--- a/layout/components/header/head.ejs
+++ b/layout/components/header/head.ejs
@@ -2,7 +2,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="keywords" content="<%= page.keywords || config.keywords || 'Hexo Theme Redefine' %>">
-    <% if (!theme.global.open_graph) { %>
+    <%
+      const openGraphConfig = theme.global?.open_graph;
+      const openGraphEnabled = openGraphConfig === true || openGraphConfig?.enable === true;
+    %>
+    <% if (!openGraphEnabled) { %>
         <meta name="description" content="<%= page.description || config.description || 'Hexo Theme Redefine' %>">
     <% }%>
     <meta name="author" content="<%= theme.info.author || config.author || 'Redefine Team' %>">
@@ -95,15 +99,10 @@
     <meta name="googlebot" content="index,follow">
     <meta name="revisit-after" content="1 days">
     
-    <% checkDeprecation(
-      theme.global.open_graph === true,
-      'open_graph',
-      "Using 'open_graph: true' is deprecated. Please update to the new format:\nglobal:\n  open_graph:\n    enable: true\n    image: your_image_path\n    description: your_description"
-    ) %>
-    <% if (theme.global.open_graph?.enable || theme.global.open_graph === true) { %>
+    <% if (openGraphEnabled) { %>
         <% 
-        let ogImage = page.og_image || theme.global.open_graph?.image;
-        let ogDescription = page.og_description || theme.global.open_graph?.description || page.description || config.description;
+        let ogImage = page.og_image || openGraphConfig?.image;
+        let ogDescription = page.og_description || openGraphConfig?.description || page.description || config.description;
         let author = page.author || config.author || 'Redefine Team';
         %>
         <%- open_graph({
@@ -219,4 +218,3 @@
         <%- renderCSS('fontawesome/sharp-solid.min.css') %>
     <% } %>
 </head>
-

--- a/scripts/deprecations/config/index.js
+++ b/scripts/deprecations/config/index.js
@@ -1,9 +1,10 @@
 "use strict";
 
 const { warnOnce } = require("../warn");
+const globalOpenGraph = require("./rules/global-open-graph");
 const homeBannerSocialLinks = require("./rules/home-banner-social-links");
 
-const RULES = [homeBannerSocialLinks];
+const RULES = [globalOpenGraph, homeBannerSocialLinks];
 
 const applyConfigDeprecations = ({ hexo, themeConfig }) => {
   if (!themeConfig) {

--- a/scripts/deprecations/config/rules/global-open-graph.js
+++ b/scripts/deprecations/config/rules/global-open-graph.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const ID = "global.open_graph.boolean";
+const MESSAGE =
+  "Config deprecation: `global.open_graph: true/false` is deprecated; use object format instead:\n" +
+  "global:\n" +
+  "  open_graph:\n" +
+  "    enable: true\n" +
+  "    image: your_image_path\n" +
+  "    description: your_description";
+
+const detect = (themeConfig) => {
+  return typeof themeConfig?.global?.open_graph === "boolean";
+};
+
+const apply = (themeConfig) => {
+  const openGraph = themeConfig?.global?.open_graph;
+  if (typeof openGraph !== "boolean") {
+    return { changed: false };
+  }
+
+  if (!themeConfig.global || typeof themeConfig.global !== "object" || Array.isArray(themeConfig.global)) {
+    themeConfig.global = {};
+  }
+
+  themeConfig.global.open_graph = {
+    enable: openGraph,
+  };
+
+  return { changed: true };
+};
+
+module.exports = {
+  id: ID,
+  message: MESSAGE,
+  detect,
+  apply,
+};


### PR DESCRIPTION
## Summary
- separate deployment environments so dev pushes report to `Dev Preview` and PR preview deploys report to `PR Preview`
- disable duplicate GitHub deployment records from the Vercel action by setting `GITHUB_DEPLOYMENT: false` in dev and PR preview deploy workflows
- make `PR Preview Build` run for all pull requests targeting `dev` by removing the path filter and limiting the base branch to `dev`