### PR TITLE
feat: add EXIF data display for images in posts

### DIFF
--- a/layout/pages/post/article-content.ejs
+++ b/layout/pages/post/article-content.ejs
@@ -67,6 +67,10 @@
 			<%- page.content %>
 		</div>
 
+		<% if (page.exif) { %>
+			<%- renderJS('libs/exif-reader.js', { swupReload: true }) %>
+		<% } %>
+
 		<% if (theme.articles.copyright.enable || theme.articles.copyright === true) { %>
 		<div class="post-copyright-info w-full my-8 px-2 sm:px-6 md:px-8">
 			<%- partial('pages/post/article-copyright') %>

--- a/scripts/filters/post-exif-handle.js
+++ b/scripts/filters/post-exif-handle.js
@@ -1,0 +1,15 @@
+"use strict";
+
+hexo.extend.filter.register('after_post_render', function(data) {
+    if (data.exif) {
+        // 给所有图片标签加上 data-exif="true"
+        data.content = data.content.replace(/<img([^>]*)>/gi, function(match, attrs) {
+            // 避免重复添加
+            if (attrs.includes('data-exif=')) {
+                return match;
+            }
+            return `<img${attrs} data-exif="true">`;
+        });
+    }
+    return data;
+});


### PR DESCRIPTION
让普通文章也可以使用瀑布流相册的图片EXIF显示功能
该功能需手动为单个文章开启，启用后该文章内的所有图片都会显示EXIF按钮，启用方法为在文章自定义中添加`exif: true`

例如：
```md
---
title: XXX
date: 2022-9-28 11:45:14
tags: [xx]
categories: [xx]
exif: true
---
```