### PR TITLE
fix: skip CDN availability logs when CDN is disabled

### DIFF
--- a/scripts/events/welcome.js
+++ b/scripts/events/welcome.js
@@ -113,6 +113,10 @@ function checkVersionAndCDNAvailability(data) {
     );
   }
 
+  if (!hexo.theme.config.cdn?.enable) {
+    return;
+  }
+
   if (data.npmMirrorCDN) {
     hexo.log.info(
       `\x1b[32m%s\x1b[0m`,


### PR DESCRIPTION
Fixes #615

### Summary

- Keep the existing version comparison warning unchanged.
- Skip CDN availability logging and status updates when `theme.cdn.enable` is disabled.
- Preserve the existing CDN checks when the option is enabled.

### Verification

- The repository has no configured test runner.
- The PR build workflow will run `npm install` and `npm run build`.