### PR TITLE
fix: suppress CDN availability logs when CDN is disabled

### DIFF
--- a/scripts/events/welcome.js
+++ b/scripts/events/welcome.js
@@ -106,22 +106,26 @@ function logFailedInfo() {
 function checkVersionAndCDNAvailability(data) {
   if (data.npmVersion > version) {
     hexo.log.warn(
-      `\x1b[33m%s\x1b[0m`,
+      `\\x1b[33m%s\\x1b[0m`,
       ensurePrefix(
         `v${version} is outdated, please update to v${data.npmVersion}!`,
       ),
     );
   }
 
+  if (!hexo.theme.config.cdn?.enable) {
+    return;
+  }
+
   if (data.npmMirrorCDN) {
     hexo.log.info(
-      `\x1b[32m%s\x1b[0m`,
+      `\\x1b[32m%s\\x1b[0m`,
       ensurePrefix(`CDN available: NPMMirror (Recommended)`),
     );
     hexo.locals.set(`cdnTestStatus_npmMirror`, 200);
   } else {
     hexo.log.warn(
-      `\x1b[31m%s\x1b[0m`,
+      `\\x1b[31m%s\\x1b[0m`,
       ensurePrefix(`NPMMirror CDN is unavailable yet.`),
     );
     hexo.locals.set(`cdnTestStatus_npmMirror`, 404);
@@ -129,13 +133,13 @@ function checkVersionAndCDNAvailability(data) {
 
   if (data.zstaticCDN) {
     hexo.log.info(
-      `\x1b[32m%s\x1b[0m`,
+      `\\x1b[32m%s\\x1b[0m`,
       ensurePrefix(`CDN available: ZStatic`),
     );
     hexo.locals.set(`cdnTestStatus_zstatic`, 200);
   } else {
     hexo.log.warn(
-      `\x1b[31m%s\x1b[0m`,
+      `\\x1b[31m%s\\x1b[0m`,
       ensurePrefix(`ZStatic CDN is unavailable yet.`),
     );
     hexo.locals.set(`cdnTestStatus_zstatic`, 404);
@@ -143,13 +147,13 @@ function checkVersionAndCDNAvailability(data) {
 
   if (data.cdnjsCDN) {
     hexo.log.info(
-      `\x1b[32m%s\x1b[0m`,
+      `\\x1b[32m%s\\x1b[0m`,
       ensurePrefix(`CDN available: CDNJS`),
     );
     hexo.locals.set(`cdnTestStatus_cdnjs`, 200);
   } else {
     hexo.log.warn(
-      `\x1b[31m%s\x1b[0m`,
+      `\\x1b[31m%s\\x1b[0m`,
       ensurePrefix(`CDNJS CDN is unavailable yet.`),
     );
     hexo.locals.set(`cdnTestStatus_cdnjs`, 404);

--- a/scripts/events/welcome.js
+++ b/scripts/events/welcome.js
@@ -106,7 +106,7 @@ function logFailedInfo() {
 function checkVersionAndCDNAvailability(data) {
   if (data.npmVersion > version) {
     hexo.log.warn(
-      `\\x1b[33m%s\\x1b[0m`,
+      `\x1b[33m%s\x1b[0m`,
       ensurePrefix(
         `v${version} is outdated, please update to v${data.npmVersion}!`,
       ),
@@ -119,13 +119,13 @@ function checkVersionAndCDNAvailability(data) {
 
   if (data.npmMirrorCDN) {
     hexo.log.info(
-      `\\x1b[32m%s\\x1b[0m`,
+      `\x1b[32m%s\x1b[0m`,
       ensurePrefix(`CDN available: NPMMirror (Recommended)`),
     );
     hexo.locals.set(`cdnTestStatus_npmMirror`, 200);
   } else {
     hexo.log.warn(
-      `\\x1b[31m%s\\x1b[0m`,
+      `\x1b[31m%s\x1b[0m`,
       ensurePrefix(`NPMMirror CDN is unavailable yet.`),
     );
     hexo.locals.set(`cdnTestStatus_npmMirror`, 404);
@@ -133,13 +133,13 @@ function checkVersionAndCDNAvailability(data) {
 
   if (data.zstaticCDN) {
     hexo.log.info(
-      `\\x1b[32m%s\\x1b[0m`,
+      `\x1b[32m%s\x1b[0m`,
       ensurePrefix(`CDN available: ZStatic`),
     );
     hexo.locals.set(`cdnTestStatus_zstatic`, 200);
   } else {
     hexo.log.warn(
-      `\\x1b[31m%s\\x1b[0m`,
+      `\x1b[31m%s\x1b[0m`,
       ensurePrefix(`ZStatic CDN is unavailable yet.`),
     );
     hexo.locals.set(`cdnTestStatus_zstatic`, 404);
@@ -147,13 +147,13 @@ function checkVersionAndCDNAvailability(data) {
 
   if (data.cdnjsCDN) {
     hexo.log.info(
-      `\\x1b[32m%s\\x1b[0m`,
+      `\x1b[32m%s\x1b[0m`,
       ensurePrefix(`CDN available: CDNJS`),
     );
     hexo.locals.set(`cdnTestStatus_cdnjs`, 200);
   } else {
     hexo.log.warn(
-      `\\x1b[31m%s\\x1b[0m`,
+      `\x1b[31m%s\x1b[0m`,
       ensurePrefix(`CDNJS CDN is unavailable yet.`),
     );
     hexo.locals.set(`cdnTestStatus_cdnjs`, 404);


### PR DESCRIPTION
## Summary

- Skip CDN availability logging and `cdnTestStatus_*` updates when `cdn.enable` is disabled.
- Preserve the existing CDN checks and status logging when CDN is enabled.
- Keep the version update warning independent of the CDN setting.

## Verification

- The repository has no configured unit-test runner.
- GitHub Actions PR Build Check will run `npm install` and `npm run build` for this scripts change.

Fixes #615