### PR TITLE
[animations]: limit fade transition to opacity

### DIFF
--- a/layout/pages/home/home-background.ejs
+++ b/layout/pages/home/home-background.ejs
@@ -26,7 +26,7 @@
     }
 </style>
 
-<div class="home-banner-background transition-fade fixed top-0 left-0 w-screen h-screen scale-125 sm:scale-110 box-border will-change-transform bg-cover">
+<div class="home-banner-background fixed top-0 left-0 w-screen h-screen scale-125 sm:scale-110 box-border will-change-transform bg-cover">
     <img src="<%- url_for(theme.home_banner.image.light) %>" alt="home-banner-background" class="w-full h-full object-cover dark:hidden">
     <img src="<%- url_for(theme.home_banner.image.dark) %>" alt="home-banner-background" class="w-full h-full object-cover hidden dark:block">
 </div>

--- a/layout/pages/home/home-banner.ejs
+++ b/layout/pages/home/home-banner.ejs
@@ -26,7 +26,7 @@
             backdrop-filter: none !important;
         }
     </style>
-    <div class="home-banner-background transition-fade fixed top-0 left-0 w-screen h-screen scale-125 sm:scale-110 box-border will-change-transform bg-cover">
+    <div class="home-banner-background fixed top-0 left-0 w-screen h-screen scale-125 sm:scale-110 box-border will-change-transform bg-cover">
         <img src="<%- url_for(theme.home_banner.image.light) %>" alt="home-banner-background" class="w-full h-full object-cover dark:hidden">
         <img src="<%- url_for(theme.home_banner.image.dark) %>" alt="home-banner-background" class="w-full h-full object-cover hidden dark:block">
     </div>

--- a/source/css/layout/animations.styl
+++ b/source/css/layout/animations.styl
@@ -1,5 +1,5 @@
 .transition-fade
-  transition 0.4s
+  transition opacity 0.4s ease
   opacity 1
 
 .transition-fade-up


### PR DESCRIPTION
Fixes #619

## Summary
- limit `.transition-fade` to opacity changes
- prevent viewport-width and transform changes from animating during light/dark mode switches
- preserve the existing 0.4-second fade with easing

## Verification
- `npm run build`
- `npx --yes stylus@0.64.0 -p source/css/layout/animations.styl`
- `git diff --check`

Generated assets were left out of the PR per the repository contribution rules.
