### PR TITLE
feat: 添加代码块折行显示按钮

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -96,7 +96,7 @@ jobs:
 
         # Install Vercel CLI first to avoid bug with next step
       - name: Install Vercel CLI
-        run: npm install -g vercel@22.0.1
+        run: npm install -g vercel@latest
 
       - name: Deploy to Vercel Action
         id: deploy-to-vercel

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Deploy to Vercel Action
         id: deploy-to-vercel
-        uses: EvanNotFound/vercel-deployment-for-github-actions@v1.2.1
+        uses: EvanNotFound/vercel-deployment-for-github-actions@v1.2.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Deploy to Vercel Action
         id: deploy-to-vercel
-        uses: EvanNotFound/vercel-deployment-for-github-actions@v1.2.0
+        uses: EvanNotFound/vercel-deployment-for-github-actions@v1.2.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Deploy to Vercel
         id: deploy-to-vercel
-        uses: EvanNotFound/vercel-deployment-for-github-actions@v1.2.0
+        uses: EvanNotFound/vercel-deployment-for-github-actions@v1.2.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Install Vercel CLI first to avoid bug with next step
       - name: Install Vercel CLI
-        run: npm install -g vercel@22.0.1
+        run: npm install -g vercel@latest
 
 
       - name: Deploy to Vercel

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Deploy to Vercel
         id: deploy-to-vercel
-        uses: EvanNotFound/vercel-deployment-for-github-actions@v1.2.1
+        uses: EvanNotFound/vercel-deployment-for-github-actions@v1.2.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm install -g vercel@latest
 
       - name: Deploy to Vercel Action
-        uses: EvanNotFound/vercel-deployment-for-github-actions@v1.1.0
+        uses: EvanNotFound/vercel-deployment-for-github-actions@v1.2.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm install -g vercel@latest
 
       - name: Deploy to Vercel Action
-        uses: EvanNotFound/vercel-deployment-for-github-actions@v1.2.1
+        uses: EvanNotFound/vercel-deployment-for-github-actions@v1.2.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -49,7 +49,7 @@ jobs:
         run: echo "HEXO_SITE_DIR=${{ github.workspace }}/hexo-site" >> $GITHUB_ENV
 
       - name: Install Vercel CLI
-        run: npm install -g vercel@22.0.1
+        run: npm install -g vercel@latest
 
       - name: Deploy to Vercel Action
         uses: EvanNotFound/vercel-deployment-for-github-actions@v1.1.0

--- a/_config.yml
+++ b/_config.yml
@@ -320,6 +320,8 @@ articles:
       enable: false # Whether to enable
       family: # Font family
       url: # Font URL to CSS file
+    # Whether to show the "toggle wrap" button on overflowing code blocks.
+    wrap_toggle: true
   # Table of contents settings
   toc:
     enable: true # Whether to enable TOC

--- a/source/css/common/codeblock/code-block.styl
+++ b/source/css/common/codeblock/code-block.styl
@@ -7,7 +7,7 @@ disable-user-select()
 .code-container
   position relative
 
-.code-container:hover .copy-button, .code-container .copy-button:focus, .code-container:hover .fold-button, .code-container .fold-button:focus
+.code-container:hover .copy-button, .code-container .copy-button:focus, .code-container:hover .fold-button, .code-container .fold-button:focus, .code-container:hover .wrap-toggle-button, .code-container .wrap-toggle-button:focus
   opacity 1
 
 .fold-button
@@ -51,6 +51,28 @@ disable-user-select()
   border 0
   right 0
   top 0
+
+.wrap-toggle-button
+  cursor pointer
+  border-radius 0
+  display inline-block
+  font-weight bold
+  line-height 1.8
+  opacity 0
+  outline 0
+  padding 6px 15px
+  position absolute
+  vertical-align middle
+  white-space nowrap
+  font-size 1rem
+  color var(--default-text-color)
+  disable-user-select()
+  transition-t('opacity', '0', '0.2', 'ease-in-out')
+  background var(--scond-background-color)
+  border 0
+  right 80px
+  top 0
+  z-index 4
 
 if (hexo-config('articles.code_block.style') == 'mac')
   .code-container

--- a/source/css/common/codeblock/highlight.styl
+++ b/source/css/common/codeblock/highlight.styl
@@ -187,3 +187,33 @@ pre
     color var(--highlight-deletion)
     display inline-block
     width 100%
+
+// Line-wrap toggle state (applied by codeBlock.js on .highlight-container)
+.highlight-container.code-wrap-enabled
+  .highlight
+    overflow-x hidden
+    td.gutter, td.code
+      vertical-align top
+    .code
+      pre
+        white-space pre-wrap !important
+        word-break break-all !important
+        overflow-wrap anywhere !important
+        br
+          display none
+        code
+          display block
+        .line
+          display block
+          min-height 1.5em
+          white-space pre-wrap !important
+          word-break break-all !important
+          overflow-wrap anywhere !important
+    .gutter
+      pre
+        white-space pre !important
+        br
+          display none
+        .line
+          display block
+          line-height 1

--- a/source/js/tools/codeBlock.js
+++ b/source/js/tools/codeBlock.js
@@ -3,9 +3,202 @@ const wrapElement = (element, wrapper) => {
   wrapper.appendChild(element);
 };
 
+// --- Wrap Toggle feature start ---
+
+let didInstallWrapToggleHooks = false;
+
+const debounce = (fn, waitMs) => {
+  let timer = null;
+  return (...args) => {
+    if (timer !== null) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      timer = null;
+      fn(...args);
+    }, waitMs);
+  };
+};
+
+const isOverflowing = (container) => {
+  const figure = container?.querySelector("figure.highlight");
+  if (!figure) return false;
+  return figure.scrollWidth > figure.clientWidth + 1;
+};
+
+const clearGutterInlineStyles = (container) => {
+  const lines = container.querySelectorAll(
+    "figure.highlight .gutter pre .line[data-gutter-synced=\"1\"]",
+  );
+  lines.forEach((line) => {
+    line.style.minHeight = "";
+    delete line.dataset.gutterSynced;
+  });
+};
+
+const syncGutterHeights = (container) => {
+  const enabled = container.classList.contains("code-wrap-enabled");
+  if (!enabled) {
+    clearGutterInlineStyles(container);
+    return;
+  }
+
+  const codeLines = container.querySelectorAll(
+    "figure.highlight .code pre .line",
+  );
+  const gutterLines = container.querySelectorAll(
+    "figure.highlight .gutter pre .line",
+  );
+
+  if (codeLines.length > 0 && gutterLines.length === codeLines.length) {
+    // Use the visual row height: delta between consecutive line tops.
+    // offsetHeight on inline `.line` spans returns the font intrinsic height,
+    // not the line-box height, so it underestimates wrapped rows.
+    const codeTops = Array.from(codeLines).map((l) =>
+      l.getBoundingClientRect().top,
+    );
+    let fallbackHeight = null;
+    for (let i = 0; i < codeLines.length; i += 1) {
+      let height;
+      if (i < codeLines.length - 1) {
+        height = codeTops[i + 1] - codeTops[i];
+      } else {
+        // Last line: reuse the last computed row height (line-height × font-size).
+        if (fallbackHeight === null) {
+          const cs = window.getComputedStyle(codeLines[0]);
+          const lh = parseFloat(cs.lineHeight);
+          fallbackHeight = Number.isFinite(lh) && lh > 0 ? lh : codeLines[i].offsetHeight;
+        }
+        height = fallbackHeight;
+      }
+      gutterLines[i].style.minHeight = `${height}px`;
+      gutterLines[i].dataset.gutterSynced = "1";
+    }
+  }
+};
+
+const ensureWrapToggleFor = (container) => {
+  // If already processed AND button already injected, nothing to do.
+  // If already processed but no button injected (wasn't overflowing), we still
+  // allow re-evaluation on resize so we inspect the injected flag here.
+  const hasButton = container.querySelector(".wrap-toggle-button") !== null;
+  if (container.dataset.wrapToggleReady === "1" && hasButton) {
+    // Still re-sync wrap heights if enabled (e.g. after resize)
+    if (container.classList.contains("code-wrap-enabled")) {
+      syncGutterHeights(container);
+    }
+    return;
+  }
+  if (container.dataset.wrapToggleReady === "1" && !hasButton) {
+    // Re-evaluate overflow on follow-up calls (resize / fonts load).
+    if (!isOverflowing(container)) {
+      return;
+    }
+    // Fall-through to inject button.
+  }
+
+  if (!isOverflowing(container)) {
+    container.dataset.wrapToggleReady = "1";
+    return;
+  }
+
+  container.insertAdjacentHTML(
+    "beforeend",
+    '<div class="wrap-toggle-button" role="button" tabindex="0"><i class="fa-solid fa-angles-right"></i></div>',
+  );
+  container.dataset.wrapButtonInjected = "1";
+
+  const button = container.querySelector(".wrap-toggle-button");
+  const icon = button?.querySelector("i");
+
+  const trigger = () => {
+    if (!button || !icon) return;
+    container.classList.toggle("code-wrap-enabled");
+    if (container.classList.contains("code-wrap-enabled")) {
+      icon.className = "fa-solid fa-angles-down";
+    } else {
+      icon.className = "fa-solid fa-angles-right";
+    }
+    syncGutterHeights(container);
+    try {
+      window.dispatchEvent(new Event("resize"));
+    } catch (_) {
+      // Ignore dispatch errors on older browsers.
+    }
+  };
+
+  if (button) {
+    button.addEventListener("click", trigger);
+    button.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " " || event.keyCode === 13 || event.keyCode === 32) {
+        event.preventDefault();
+        trigger();
+      }
+    });
+  }
+
+  container.dataset.wrapToggleReady = "1";
+  // Sync once in case the block was previously toggled via state restoration.
+  if (container.classList.contains("code-wrap-enabled")) {
+    syncGutterHeights(container);
+  }
+};
+
+const scanAllWrapToggles = () => {
+  const containers = document.querySelectorAll(".highlight-container");
+  containers.forEach((container) => {
+    ensureWrapToggleFor(container);
+  });
+};
+
+const debouncedScanWrapToggles = debounce(scanAllWrapToggles, 200);
+
+const installWrapToggleHooks = () => {
+  if (didInstallWrapToggleHooks) {
+    return;
+  }
+  didInstallWrapToggleHooks = true;
+
+  window.addEventListener("resize", debouncedScanWrapToggles);
+
+  if (typeof document !== "undefined" && document.fonts && document.fonts.ready) {
+    document.fonts.ready
+      .then(() => {
+        setTimeout(scanAllWrapToggles, 0);
+      })
+      .catch(() => {
+        // No-op: fonts promise rejection shouldn't break anything.
+      });
+  }
+};
+
+// --- Wrap Toggle feature end ---
+
 const initCopyCode = () => {
+  const wrapToggleEnabled =
+    (typeof window !== "undefined" &&
+      window.theme &&
+      window.theme.articles &&
+      window.theme.articles.code_block &&
+      window.theme.articles.code_block.wrap_toggle === true) ||
+    false;
+
+  if (wrapToggleEnabled) {
+    installWrapToggleHooks();
+  }
+
   document.querySelectorAll("figure.highlight").forEach((element) => {
     if (element.dataset.codeBlockReady || element.parentElement?.classList.contains("highlight-container")) {
+      // If already wrapped but wrap toggle wasn't processed yet, try to do so now
+      // (can happen on pages where script execution order varies).
+      const container = element.parentElement;
+      if (
+        wrapToggleEnabled &&
+        container &&
+        container.classList.contains("highlight-container")
+      ) {
+        ensureWrapToggleFor(container);
+      }
       return;
     }
 
@@ -50,6 +243,10 @@ const initCopyCode = () => {
         ? "fa-solid fa-chevron-up"
         : "fa-solid fa-chevron-down";
     });
+
+    if (wrapToggleEnabled) {
+      ensureWrapToggleFor(container);
+    }
   });
 };
 


### PR DESCRIPTION
# feat:添加代码块折行显示按钮

## 功能效果

- 为每个代码块添加折行显示的按钮
- 该按钮与折叠代码块按钮和复制按钮显示在同一行
- 折行按钮默认透明，和复制、折叠按钮保持一致，当鼠标悬停在代码块上时按钮才会显示
- 只有在代码块实际内容溢出（`scrollWidth` > `clientWidth`）时该按钮才会出现
- 点击按钮在整行显示和折行显示之间切换，效果只作用于当前代码块，默认为整行显示
- 未折叠的代码行号不变，折叠后的代码行号为空白

## 文件修改

1. `_config.yml`
    在 `articles.code_block` 下新增开关 `wrap_toggle: true`（默认开启）
2. `source/js/tools/codeBlock.js`
    在 `initCopyCode()` 中添加：
     1. 开关判断
     2. 溢出检测
     3. 条件注入图标 `wrap-toggle` 按钮
     4. 切换状态
     5. 行号高度同步
     6. 一次性全局 `resize` 监听
3. `source/css/common/codeblock/code-block.styl`
    新增 `.wrap-toggle-button` 样式：
    - 位置 `right:80px`
    - 初始 `opacity 0`
    - 和 `.copy-button` / `.fold-button` 在同一条 `hover` 选择器里被激活 `opacity 1`
4. `source/css/common/codeblock/highlight.styl`
    新增 `.highlight-container.code-wrap-enabled` 下 pre / code / .line 的折行 white-space / word-break 规则

## 已知问题

折叠代码后原来的行号会有轻微偏移，但不影响阅读

## 预览

1. 未折叠

<img width="1418" height="1071" alt="image" src="https://github.com/user-attachments/assets/b11bb849-52f5-46c4-916e-f67d6a18176d" />

2. 折叠后

<img width="1399" height="1122" alt="image" src="https://github.com/user-attachments/assets/5ab61c4d-c6b2-42ef-84dd-317ffc3a9e92" />

> The following translation is completed by AI.

# feat: Add code‑block word‑wrap toggle button

## Feature Behavior

- Add a word‑wrap toggle button for each code block
- The button appears on the same row as the code‑fold button and copy button
- The toggle button is transparent by default, consistent with the copy and fold buttons; it becomes visible only when hovering over the code block
- The button is rendered **only** when the code‑block content overflows (`scrollWidth` > `clientWidth`)
- Click the button to toggle between no‑wrap and word‑wrap modes; the change applies exclusively to the current code block, with no‑wrap as the default state
- Line numbers remain unchanged for unfolded code; line‑number areas show blank content for folded code

## File Modifications

1. `_config.yml`
    Add the switch `wrap_toggle: true` under `articles.code_block` (enabled by default)
2. `source/js/tools/codeBlock.js`
    Add logic inside `initCopyCode()` for:
    1. Configuration‑switch judgment
    2. Overflow detection
    3. Conditional injection of the `wrap‑toggle` icon button
    4. State‑switching logic
    5. Line‑number height synchronization
    6. One‑shot global `resize` event listener
3. `source/css/common/codeblock/code‑block.styl`
    Add styles for `.wrap‑toggle‑button`:
    - Position: `right: 80px`
    - Initial `opacity: 0`
    - Activated to `opacity: 1` within the same `hover` selector as `.copy‑button` / `.fold‑button`
4. `source/css/common/codeblock/highlight.styl`
    Add `white‑space` / `word‑break` wrapping rules for `pre` / `code` / `.line` under `.highlight‑container.code‑wrap‑enabled`

## Known Issues

Slight offset occurs on original line numbers after code folding, though it does not impair readability.
